### PR TITLE
feat: add option to login to fairos

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -16,12 +16,16 @@ interface ExportUserResponse {
   address: string;
 }
 
+export function login(userName: string, password: string): Promise<void> {
+  return axios.post('v2/user/login', { userName, password });
+}
+
 export async function importUser(
   data: ImportUserData
 ): Promise<ImportUserResponse> {
-  return axios.post('user/import', data);
+  return axios.post('v1/user/import', data);
 }
 
 export async function exportUser(): Promise<ExportUserResponse> {
-  return (await axios.post('user/export')).data;
+  return (await axios.post('v1/user/export')).data;
 }

--- a/src/components/Forms/LoginForm/LoginForm.tsx
+++ b/src/components/Forms/LoginForm/LoginForm.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { FC, useContext, useState } from 'react';
-import { useRouter } from 'next/router';
+import router from 'next/router';
 import { useForm } from 'react-hook-form';
 import UserContext from '@context/UserContext';
 import PodContext from '@context/PodContext';
 import DisclaimerMessage from '@components/DisclaimerMessage/DisclaimerMessage';
 import { AuthenticationHeader } from '@components/Headers';
 import FeedbackMessage from '@components/FeedbackMessage/FeedbackMessage';
-import { AuthenticationInput } from '@components/Inputs';
+import { AuthenticationInput, Checkbox } from '@components/Inputs';
 import { Button } from '@components/Buttons';
 import { useFdpStorage } from '@context/FdpStorageContext';
 import { login } from '@api/user';
@@ -26,7 +26,9 @@ const LoginForm: FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
 
   const { fdpClient, setWallet } = useFdpStorage();
-  const router = useRouter();
+  const [logToFairos, setLogToFairos] = useState<boolean>(
+    router.query.fairos === 'true'
+  );
 
   const onSubmit = async (data: { user_name: string; password: string }) => {
     try {
@@ -34,7 +36,7 @@ const LoginForm: FC = () => {
       const { user_name, password } = data;
       const wallet = await fdpClient.account.login(user_name, password);
       setWallet(wallet);
-      if (router.query.fairos === 'true') {
+      if (logToFairos) {
         await login(user_name, password);
       }
       router.push('/overview');
@@ -100,6 +102,15 @@ const LoginForm: FC = () => {
               type="submit"
               variant="secondary"
               label="Continue"
+            />
+          </div>
+
+          <div className="mt-14 text-center">
+            <Checkbox
+              name="fairos"
+              label="Login with FairOS (this option will log you in to a remote server)"
+              onChange={() => setLogToFairos(!logToFairos)}
+              defaultValue={logToFairos}
             />
           </div>
 

--- a/src/components/Forms/LoginForm/LoginForm.tsx
+++ b/src/components/Forms/LoginForm/LoginForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { FC, useContext, useState } from 'react';
-import router from 'next/router';
+import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import UserContext from '@context/UserContext';
 import PodContext from '@context/PodContext';
@@ -10,6 +10,7 @@ import FeedbackMessage from '@components/FeedbackMessage/FeedbackMessage';
 import { AuthenticationInput } from '@components/Inputs';
 import { Button } from '@components/Buttons';
 import { useFdpStorage } from '@context/FdpStorageContext';
+import { login } from '@api/user';
 
 const LoginForm: FC = () => {
   const CREATE_USER_URL = process.env.NEXT_PUBLIC_CREATE_ACCOUNT_REDIRECT;
@@ -25,6 +26,7 @@ const LoginForm: FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
 
   const { fdpClient, setWallet } = useFdpStorage();
+  const router = useRouter();
 
   const onSubmit = async (data: { user_name: string; password: string }) => {
     try {
@@ -32,6 +34,9 @@ const LoginForm: FC = () => {
       const { user_name, password } = data;
       const wallet = await fdpClient.account.login(user_name, password);
       setWallet(wallet);
+      if (router.query.fairos === 'true') {
+        await login(user_name, password);
+      }
       router.push('/overview');
     } catch (error) {
       setErrorMessage(error.message);

--- a/src/components/Forms/LoginForm/LoginForm.tsx
+++ b/src/components/Forms/LoginForm/LoginForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { FC, useContext, useState } from 'react';
-import router from 'next/router';
+import { FC, useContext, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import UserContext from '@context/UserContext';
 import PodContext from '@context/PodContext';
@@ -26,9 +26,10 @@ const LoginForm: FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
 
   const { fdpClient, setWallet } = useFdpStorage();
-  const [logToFairos, setLogToFairos] = useState<boolean>(
-    router.query.fairos === 'true'
+  const [logToFairos, setLogToFairos] = useState<boolean | undefined>(
+    undefined
   );
+  const router = useRouter();
 
   const onSubmit = async (data: { user_name: string; password: string }) => {
     try {
@@ -46,6 +47,17 @@ const LoginForm: FC = () => {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (router.isReady) {
+      setLogToFairos(router.query.fairos === 'true');
+    }
+  }, [router.isReady]);
+
+  // It must wait for the router to be initialized
+  if (logToFairos === undefined) {
+    return null;
+  }
 
   return (
     <div className="flex flex-col px-3 justify-center items-center">

--- a/src/components/Inputs/Checkbox/Checkbox.tsx
+++ b/src/components/Inputs/Checkbox/Checkbox.tsx
@@ -11,9 +11,15 @@ interface CheckboxProps {
   name: string;
   label: string;
   onChange: any;
+  defaultValue?: boolean;
 }
 
-const Checkbox: FC<CheckboxProps> = ({ name, label, onChange }) => {
+const Checkbox: FC<CheckboxProps> = ({
+  name,
+  label,
+  onChange,
+  defaultValue,
+}) => {
   const { theme } = useContext(ThemeContext);
 
   return (
@@ -23,6 +29,7 @@ const Checkbox: FC<CheckboxProps> = ({ name, label, onChange }) => {
         id={name}
         type="checkbox"
         value={name}
+        defaultChecked={defaultValue}
         className={`${classes.checkbox} absolute top-4 left-1 w-6 h-6 opacity-0 cursor-pointer`}
         onChange={onChange}
       />


### PR DESCRIPTION
In order to use other applications with fairdrive, like consent viewer, the user must be logged in to fairos. With the new version of fairdrive which uses fdp-storage, that's no longer the case. So there must be an option for the user to login to fairos as well and by that have access to other apps.