### PR TITLE
add links to about page

### DIFF
--- a/src/components/Footers/AuthenticationFooter/AuthenticationFooter.tsx
+++ b/src/components/Footers/AuthenticationFooter/AuthenticationFooter.tsx
@@ -4,6 +4,11 @@ import Link from 'next/link';
 const AuthenticationFooter: FC = () => {
   return (
     <div className="flex justify-evenly items-center w-full h-16 bg-white shadow-top">
+      <Link href="/about">
+        <a className="font-medium text-base text-color-accents-purple-black dark:text-color-accents-soft-lavender leading-6">
+          About
+        </a>
+      </Link>
       <Link href="/privacy-policy">
         <a className="font-medium text-base text-color-accents-purple-black dark:text-color-accents-soft-lavender leading-6">
           Privacy Policy

--- a/src/components/Footers/MainFooter/MainFooter.tsx
+++ b/src/components/Footers/MainFooter/MainFooter.tsx
@@ -109,6 +109,18 @@ const MainFooter: FC = () => {
             <StarDarkIcon className="inline-block" />
           )}
 
+          <Link href="/about">
+            <a className="font-normal text-xs text-color-accents-purple-heavy dark:text-color-shade-light-1-night leading-6">
+              About
+            </a>
+          </Link>
+
+          {theme === 'light' ? (
+            <StarLightIcon className="inline-block" />
+          ) : (
+            <StarDarkIcon className="inline-block" />
+          )}
+
           <Link href="/terms">
             <a className="font-normal text-xs text-color-accents-purple-heavy dark:text-color-shade-light-1-night leading-6">
               Terms & Conditions


### PR DESCRIPTION
suggestion to add about links so we can have loose "app" subdomain, have the main app on "root" subdomain and have landing page on /about