### PR TITLE
fix: fdp-storage context

### DIFF
--- a/src/components/Connect/Metamask/MetamaskConnect.tsx
+++ b/src/components/Connect/Metamask/MetamaskConnect.tsx
@@ -20,7 +20,7 @@ const MetamaskConnect = ({ onConnect }: MetamaskConnectProps) => {
   const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [loading, setLoading] = useState<boolean>(false);
   const {
-    fdpClient,
+    fdpClientRef,
     setIsLoggedIn,
     setWallet,
     setFdpStorageType,
@@ -52,7 +52,9 @@ const MetamaskConnect = ({ onConnect }: MetamaskConnectProps) => {
     try {
       const wallet = await getSignatureWallet(password);
       markInviteAsParticipated();
-      fdpClient.account.setAccountFromMnemonic(wallet.mnemonic.phrase);
+      fdpClientRef.current.account.setAccountFromMnemonic(
+        wallet.mnemonic.phrase
+      );
       setFdpStorageType('native');
       setIsLoggedIn(true);
       setLoginType('metamask');

--- a/src/components/Dropdowns/DriveItemDropdown/DriveItemMenu.tsx
+++ b/src/components/Dropdowns/DriveItemDropdown/DriveItemMenu.tsx
@@ -33,14 +33,14 @@ const DriveItemMenu: FC<DriveItemMenuProps> = ({
 }) => {
   const { trackEvent } = useMatomo();
   const { activePod, directoryName } = useContext(PodContext);
-  const { fdpClient, getAccountAddress } = useFdpStorage();
+  const { fdpClientRef, getAccountAddress } = useFdpStorage();
   const [showShareFileModal, setShowShareFileModal] = useState(false);
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] = useState(false);
   const previewLabel = type === 'file' ? 'Preview' : 'Open';
 
   const handleDownloadClick = async () => {
     try {
-      const response = await downloadFile(fdpClient, {
+      const response = await downloadFile(fdpClientRef.current, {
         filename: data?.name,
         directory: directoryName,
         podName: activePod,
@@ -74,7 +74,7 @@ const DriveItemMenu: FC<DriveItemMenuProps> = ({
     const fdpPath = getFdpPathByDirectory(directory);
     const itemName = data?.name;
     try {
-      await deleteFile(fdpClient, {
+      await deleteFile(fdpClientRef.current, {
         file_name: itemName,
         podName: activePod,
         path: formatDirectory(directoryName),
@@ -113,7 +113,7 @@ const DriveItemMenu: FC<DriveItemMenuProps> = ({
       (directoryName !== 'root' ? '/' + directoryName + '/' : '/') + data.name;
 
     try {
-      await deleteDirectory(fdpClient, {
+      await deleteDirectory(fdpClientRef.current, {
         podName: activePod,
         path: deletePath,
       });

--- a/src/components/Forms/LoginForm/LoginForm.tsx
+++ b/src/components/Forms/LoginForm/LoginForm.tsx
@@ -29,13 +29,12 @@ const LoginForm: FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
 
   const {
-    fdpClient,
+    fdpClientRef,
     setWallet,
     setIsLoggedIn,
     setFdpStorageType,
     setLoginType,
     storageType,
-    setEnsConfig,
   } = useFdpStorage();
   const router = useRouter();
 
@@ -44,10 +43,12 @@ const LoginForm: FC = () => {
       setLoading(true);
       setErrorMessage(null);
       const { user_name, password } = data;
-      const fdpClient = setEnsConfig(network.config);
-      const wallet = await fdpClient.account.login(user_name, password);
+      setFdpStorageType('native', network.config);
+      const wallet = await fdpClientRef.current.account.login(
+        user_name,
+        password
+      );
       setWallet(wallet);
-      setFdpStorageType('native');
       setIsLoggedIn(true);
       setLoginType('username');
       setUser(user_name);
@@ -79,11 +80,13 @@ const LoginForm: FC = () => {
       return;
     }
 
+    const fdpClient = fdpClientRef.current;
+
     // init the FDP cache if is not initialized yet
     if (fdpClient?.cache?.object && isEmpty(fdpClient.cache.object)) {
       fdpClient.cache.object = JSON.parse(getCache(CacheType.FDP));
     }
-  }, [fdpClient.cache, storageType]);
+  }, [fdpClientRef.current?.cache, storageType]);
 
   return (
     <div className="flex flex-col px-3 justify-center items-center">

--- a/src/components/Modals/CreateFolderModal/CreateFolderModal.tsx
+++ b/src/components/Modals/CreateFolderModal/CreateFolderModal.tsx
@@ -24,7 +24,7 @@ const CreateFolderModal: FC<CreatorModalProps> = ({
 
   const { trackEvent } = useMatomo();
   const { activePod, directoryName } = useContext(PodContext);
-  const { fdpClient, getAccountAddress } = useFdpStorage();
+  const { fdpClientRef, getAccountAddress } = useFdpStorage();
   const [newFolderName, setNewFolderName] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -36,7 +36,7 @@ const CreateFolderModal: FC<CreatorModalProps> = ({
       const fdpPath = getFdpPathByDirectory(directoryName || 'root');
 
       const item = await createDirectory(
-        fdpClient,
+        fdpClientRef.current,
         activePod,
         fdpPath,
         newFolderName

--- a/src/components/Modals/CreatePodModal/CreatePodModal.tsx
+++ b/src/components/Modals/CreatePodModal/CreatePodModal.tsx
@@ -22,7 +22,7 @@ const CreatePodModal: FC<CreatePodModalProps> = ({
   refreshPods,
 }) => {
   const { trackEvent } = useMatomo();
-  const { fdpClient } = useFdpStorage();
+  const { fdpClientRef } = useFdpStorage();
   const [loading, setLoading] = useState(false);
 
   const [newPodName, setNewPodName] = useState('');
@@ -31,7 +31,7 @@ const CreatePodModal: FC<CreatePodModalProps> = ({
   const handleCreateNewPod = async () => {
     setLoading(true);
     try {
-      await createPod(fdpClient, newPodName);
+      await createPod(fdpClientRef.current, newPodName);
       trackEvent({
         category: 'Create',
         action: `Create Pod`,

--- a/src/components/Modals/ImportFileModal/ImportFileModal.tsx
+++ b/src/components/Modals/ImportFileModal/ImportFileModal.tsx
@@ -17,13 +17,18 @@ const ImportFileModal: FC<CreatorModalProps> = ({
   updateDrive,
 }) => {
   const { activePod, directoryName } = useContext(PodContext);
-  const { fdpClient } = useFdpStorage();
+  const { fdpClientRef } = useFdpStorage();
   const [importCode, setImportCode] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
   const handleImportFile = async () => {
     try {
-      await receiveFile(fdpClient, importCode, activePod, directoryName);
+      await receiveFile(
+        fdpClientRef.current,
+        importCode,
+        activePod,
+        directoryName
+      );
       updateDrive();
       closeModal();
     } catch {

--- a/src/components/Modals/ImportPodModal/ImportPodModal.tsx
+++ b/src/components/Modals/ImportPodModal/ImportPodModal.tsx
@@ -18,12 +18,12 @@ const ImportPodModal: FC<ImportPodModalProps> = ({
   closeModal,
   refreshPods,
 }) => {
-  const { fdpClient } = useFdpStorage();
+  const { fdpClientRef } = useFdpStorage();
   const [importCode, setImportCode] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
   const handleImportPod = () => {
-    receivePod(fdpClient, importCode)
+    receivePod(fdpClientRef.current, importCode)
       .then(() => {
         refreshPods();
         closeModal();

--- a/src/components/Modals/PreviewFileModal/PreviewFileModal.tsx
+++ b/src/components/Modals/PreviewFileModal/PreviewFileModal.tsx
@@ -47,7 +47,7 @@ const PreviewFileModal: FC<PreviewModalProps> = ({
   previewFile,
   updateDrive,
 }) => {
-  const { fdpClient } = useFdpStorage();
+  const { fdpClientRef } = useFdpStorage();
   const { trackEvent } = useMatomo();
   const { theme } = useContext(ThemeContext);
   const { activePod, directoryName } = useContext(PodContext);
@@ -60,7 +60,7 @@ const PreviewFileModal: FC<PreviewModalProps> = ({
 
   useEffect(() => {
     setLoading(true);
-    downloadFile(fdpClient, {
+    downloadFile(fdpClientRef.current, {
       filename: previewFile?.name,
       directory: directoryName,
       podName: activePod,
@@ -87,7 +87,7 @@ const PreviewFileModal: FC<PreviewModalProps> = ({
   const handleDownloadFile = () => {
     setLoading(true);
 
-    downloadFile(fdpClient, {
+    downloadFile(fdpClientRef.current, {
       filename: previewFile?.name,
       directory: directoryName,
       podName: activePod,
@@ -113,7 +113,7 @@ const PreviewFileModal: FC<PreviewModalProps> = ({
   const handleDeleteFile = () => {
     setLoading(true);
 
-    deleteFile(fdpClient, {
+    deleteFile(fdpClientRef.current, {
       file_name: previewFile?.name,
       podName: activePod,
       path: formatDirectory(directoryName),

--- a/src/components/Modals/ShareFileModal/ShareFileModal.tsx
+++ b/src/components/Modals/ShareFileModal/ShareFileModal.tsx
@@ -29,11 +29,11 @@ const ShareFileModal: FC<ShareFileModalProps> = ({
   path,
 }) => {
   const { trackEvent } = useMatomo();
-  const { fdpClient } = useFdpStorage();
+  const { fdpClientRef } = useFdpStorage();
   const [shareCode, setShareCode] = useState('');
 
   useEffect(() => {
-    shareFile(fdpClient, {
+    shareFile(fdpClientRef.current, {
       fileName: fileName,
       podName: podName,
       path_file: path,

--- a/src/components/Modals/UploadFileModal/UploadFileModal.tsx
+++ b/src/components/Modals/UploadFileModal/UploadFileModal.tsx
@@ -35,7 +35,7 @@ const UploadFileModal: FC<CreatorModalProps> = ({
 
   const [fileToUpload, setFileToUpload] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');
-  const { fdpClient, getAccountAddress } = useFdpStorage();
+  const { fdpClientRef, getAccountAddress } = useFdpStorage();
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: (acceptedFiles: any) => {
       if (activePod) {
@@ -54,7 +54,7 @@ const UploadFileModal: FC<CreatorModalProps> = ({
       const userAddress = await getAccountAddress();
       const directory = directoryName || 'root';
       const fdpPath = getFdpPathByDirectory(directory);
-      const item = await uploadFile(fdpClient, {
+      const item = await uploadFile(fdpClientRef.current, {
         file: fileToUpload,
         directory: directoryName,
         podName: activePod,

--- a/src/components/NavigationBars/DriveSideBar/DriveSideBar.tsx
+++ b/src/components/NavigationBars/DriveSideBar/DriveSideBar.tsx
@@ -26,7 +26,7 @@ const DriveSideBar: FC = () => {
   const { theme } = useContext(ThemeContext);
   const { pods, setPods, activePod, setActivePod, setDirectoryName } =
     useContext(PodContext);
-  const { fdpClient } = useFdpStorage();
+  const { fdpClientRef } = useFdpStorage();
   const [loading, setLoading] = useState(false);
 
   const [activeTab, setActiveTab] = useState('private');
@@ -42,7 +42,7 @@ const DriveSideBar: FC = () => {
   const handleFetchPods = async () => {
     setLoading(true);
     try {
-      const response = await getPods(fdpClient);
+      const response = await getPods(fdpClientRef.current);
       setPods(response);
     } catch (error) {
       console.log('Error: Pods could not be fetched (DriveSideBar)!');

--- a/src/components/NavigationBars/MainNavigationBar/UserDropdown/UserDropdown.tsx
+++ b/src/components/NavigationBars/MainNavigationBar/UserDropdown/UserDropdown.tsx
@@ -20,7 +20,7 @@ const UserDropdown: FC<UserDropdownProps> = ({
 }) => {
   const { user, setUser } = useContext(UserContext);
   const {
-    fdpClient,
+    fdpClientRef,
     setIsLoggedIn,
     setFdpStorageType,
     setWallet,
@@ -28,7 +28,7 @@ const UserDropdown: FC<UserDropdownProps> = ({
   } = useFdpStorage();
   const { clearPodContext } = useContext(PodContext);
 
-  const address = fdpClient?.account?.wallet?.address;
+  const address = fdpClientRef.current?.account?.wallet?.address;
 
   const handleCopyClick = async () => {
     copy(user || address);

--- a/src/pages/drive/index.tsx
+++ b/src/pages/drive/index.tsx
@@ -57,7 +57,7 @@ const Drive: FC = () => {
   const [driveView, setDriveView] = useState<'grid' | 'list'>('grid');
   const [driveSort, setDriveSort] = useState('a-z');
   const [loading, setLoading] = useState(false);
-  const { fdpClient, getAccountAddress } = useFdpStorage();
+  const { fdpClientRef, getAccountAddress } = useFdpStorage();
 
   useEffect(() => {
     trackPageView({
@@ -99,7 +99,7 @@ const Drive: FC = () => {
 
     try {
       const response = await getFilesAndDirectories(
-        fdpClient,
+        fdpClientRef.current,
         activePod,
         directory
       );
@@ -121,8 +121,10 @@ const Drive: FC = () => {
         );
         if (invalidationResult === InvalidationResult.FULL) {
           // update FDP cache if it is available
-          if (fdpClient?.cache?.object) {
-            fdpClient.cache.object = JSON.parse(getCache(CacheType.FDP));
+          if (fdpClientRef.current?.cache?.object) {
+            fdpClientRef.current.cache.object = JSON.parse(
+              getCache(CacheType.FDP)
+            );
           }
 
           clearPodContext();
@@ -139,7 +141,7 @@ const Drive: FC = () => {
   const handleFetchPods = async () => {
     try {
       setLoading(true);
-      const response = await getPods(fdpClient);
+      const response = await getPods(fdpClientRef.current);
       setPods(response);
     } catch (error) {
       console.log('Error: Pods could not be fetched (drive index)!');


### PR DESCRIPTION
There was a bug with the latest changes to the network selector. But additionally, the `fdpClient` property was an anti-pattern. Because it is a mutable object, it can't be stored as a state variable, instead it is now changed to a reference.