### PR TITLE
feat: changed the order of metamask auth

### DIFF
--- a/src/components/Connect/Metamask/MetamaskConnect.tsx
+++ b/src/components/Connect/Metamask/MetamaskConnect.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@components/Buttons';
 import MetamaskIcon from '@media/UI/metamask.svg';
-import { getSignatureWallet, isMetamaskAvailable } from '@utils/metamask';
+import { decryptWallet, getBasicSignatureWallet, isMetamaskAvailable } from '@utils/metamask'
 import { useRouter } from 'next/router';
 import { useFdpStorage } from '@context/FdpStorageContext';
 import MetamaskNotFoundModal from '@components/Modals/MetamaskNotFoundModal/MetamaskNotFoundModal';
@@ -16,6 +16,7 @@ interface MetamaskConnectProps {
 }
 
 const MetamaskConnect = ({ onConnect }: MetamaskConnectProps) => {
+  const [localBasicWallet, setLocalBasicWallet] = useState(null);
   const [showNotFoundModal, setShowNotFoundModal] = useState(false);
   const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [loading, setLoading] = useState<boolean>(false);
@@ -50,7 +51,7 @@ const MetamaskConnect = ({ onConnect }: MetamaskConnectProps) => {
    */
   const handlePassword = async (password: string): Promise<void> => {
     try {
-      const wallet = await getSignatureWallet(password);
+      const wallet = await decryptWallet(localBasicWallet, password);
       markInviteAsParticipated();
       fdpClientRef.current.account.setAccountFromMnemonic(
         wallet.mnemonic.phrase
@@ -81,6 +82,7 @@ const MetamaskConnect = ({ onConnect }: MetamaskConnectProps) => {
         return;
       }
 
+      setLocalBasicWallet(await getBasicSignatureWallet());
       setShowPasswordModal(true);
     } catch (error) {
       console.error(error);

--- a/src/components/Connect/Metamask/MetamaskConnect.tsx
+++ b/src/components/Connect/Metamask/MetamaskConnect.tsx
@@ -1,6 +1,10 @@
 import { Button } from '@components/Buttons';
 import MetamaskIcon from '@media/UI/metamask.svg';
-import { decryptWallet, getBasicSignatureWallet, isMetamaskAvailable } from '@utils/metamask'
+import {
+  decryptWallet,
+  getBasicSignatureWallet,
+  isMetamaskAvailable,
+} from '@utils/metamask';
 import { useRouter } from 'next/router';
 import { useFdpStorage } from '@context/FdpStorageContext';
 import MetamaskNotFoundModal from '@components/Modals/MetamaskNotFoundModal/MetamaskNotFoundModal';

--- a/src/components/Modals/PasswordModal/PasswordModal.tsx
+++ b/src/components/Modals/PasswordModal/PasswordModal.tsx
@@ -42,13 +42,9 @@ const PasswordModal: FC<PasswordModalProps> = ({
     <Modal
       showModal={showModal}
       closeModal={closeModal}
-      headerTitle="Enter password"
+      headerTitle="Enter passphrase"
     >
       <form onSubmit={handleSubmit(handleSubmitButton)} className="w-full">
-        <p className="text-sm mb-4">
-          Your passphrase is used for the encryption and decryption of your
-          data. Do not share it.
-        </p>
         <AuthenticationInput
           label=""
           id="password"
@@ -65,6 +61,11 @@ const PasswordModal: FC<PasswordModalProps> = ({
           }}
           error={errors.password as FieldError}
         />
+
+        <p className="text-sm mb-5">
+          Your passphrase is used for the encryption and decryption of your
+          data. Do not share it.
+        </p>
 
         <div className="text-center">
           <Button

--- a/src/components/Modals/PasswordModal/PasswordModal.tsx
+++ b/src/components/Modals/PasswordModal/PasswordModal.tsx
@@ -45,6 +45,10 @@ const PasswordModal: FC<PasswordModalProps> = ({
       headerTitle="Enter password"
     >
       <form onSubmit={handleSubmit(handleSubmitButton)} className="w-full">
+        <p className="text-sm mb-4">
+          Your passphrase is used for the encryption and decryption of your
+          data. Do not share it.
+        </p>
         <AuthenticationInput
           label=""
           id="password"

--- a/src/utils/metamask.ts
+++ b/src/utils/metamask.ts
@@ -74,21 +74,33 @@ export const signatureToWallet = (signature: string): Wallet => {
 };
 
 /**
- * Creates a wallet using Metamask signature
+ * Creates a basic wallet using Metamask signature
  */
-export const getSignatureWallet = async (password = ''): Promise<Wallet> => {
+export const getBasicSignatureWallet = async (
+  password = ''
+): Promise<Wallet> => {
   const address = await getAddress();
   const signature = await getSignature(address, SIGN_WALLET_DATA);
   const wallet = signatureToWallet(signature);
   if (password) {
-    const signature = await wallet.signMessage(
-      utils.sha256(utils.toUtf8Bytes(password))
-    );
-
-    return signatureToWallet(signature);
+    return decryptWallet(wallet, password);
   } else {
     return wallet;
   }
+};
+
+/**
+ * Extracts an encrypted wallet from basic wallet
+ *
+ * @param wallet Basic wallet
+ * @param password Password
+ */
+export const decryptWallet = async (wallet: Wallet, password: string) => {
+  const signature = await wallet.signMessage(
+    utils.sha256(utils.toUtf8Bytes(password))
+  );
+
+  return signatureToWallet(signature);
 };
 
 /**

--- a/test/unit/metamask.test.ts
+++ b/test/unit/metamask.test.ts
@@ -1,10 +1,9 @@
 import * as metamaskUtil from '../../src/utils/metamask';
 import {
-  getAddress,
-  getSignature,
+  decryptWallet,
   SIGN_WALLET_DATA,
+  getBasicSignatureWallet,
 } from '../../src/utils/metamask';
-import { getSignatureWallet } from '../../src/utils/metamask';
 import { Wallet } from 'ethers';
 
 const privateKey =
@@ -29,21 +28,30 @@ describe('Metamask', () => {
     );
   });
 
-  it('getSignatureWallet without password', async () => {
+  it('getBasicSignatureWallet without password', async () => {
     const expectedAddress = '0x61E18Ac267f4d5af06D421DeA020818255678649';
-    const wallet = await getSignatureWallet();
+    const wallet = await getBasicSignatureWallet();
     expect(wallet.address).toBe(expectedAddress);
   });
 
-  it('getSignatureWallet with password', async () => {
+  it('getBasicSignatureWallet with password', async () => {
     const expectedEasyAddress = '0xbb434d1D294455Aa6d85393187770b46Ecc11F95';
     const expectedStrongAddress = '0x1E721A883CeEbF8e2618140Ea00BE18dfC642238';
     const easyPassword = 'oneTwoThree';
     const strongPassword = 'Hello & world! =-0987654321`';
-    const wallet1 = await getSignatureWallet(easyPassword);
-    expect(wallet1.address).toBe(expectedEasyAddress);
+    const easyWallet = await getBasicSignatureWallet(easyPassword);
+    expect(easyWallet.address).toBe(expectedEasyAddress);
 
-    const wallet2 = await getSignatureWallet(strongPassword);
-    expect(wallet2.address).toBe(expectedStrongAddress);
+    const strongWallet = await getBasicSignatureWallet(strongPassword);
+    expect(strongWallet.address).toBe(expectedStrongAddress);
+
+    // checks two steps getting of a wallet: 1 - get basic wallet, 2 - get encrypted wallet
+    const walletBasic = await getBasicSignatureWallet();
+    expect((await decryptWallet(walletBasic, easyPassword)).address).toEqual(
+      easyWallet.address
+    );
+    expect((await decryptWallet(walletBasic, strongPassword)).address).toEqual(
+      strongWallet.address
+    );
   });
 });


### PR DESCRIPTION
The users will now first authenticate with Metamask, followed by entering their password to access the decrypted wallet. 

Close: https://github.com/fairDataSociety/fairdrive-theapp/issues/426