### PR TITLE
fix: blur when theme not chosen

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -305,11 +305,9 @@
   scrollbar-width: none; /* Firefox */
 }
 
-.light {
-  .blurred-text {
-    color: transparent;
-    text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
-  }
+.blurred-text {
+  color: transparent;
+  text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 }
 
 .dark {


### PR DESCRIPTION
Fixed a problem with blur in invites when you visit the site for the first time and do not select a theme (light/dark).

Close https://github.com/fairDataSociety/fairdrive-theapp/issues/386

