### PR TITLE
fix: metamask workflow for clean installation

### DIFF
--- a/src/components/Connect/Metamask/MetamaskConnect.tsx
+++ b/src/components/Connect/Metamask/MetamaskConnect.tsx
@@ -4,7 +4,6 @@ import {
   decryptWallet,
   getBasicSignatureWallet,
   getMetamaskDeeplinkUrl,
-  requestAccounts,
 } from '@utils/metamask';
 import { useRouter } from 'next/router';
 import { getDefaultNetwork, useFdpStorage } from '@context/FdpStorageContext';
@@ -113,10 +112,10 @@ const MetamaskConnect = ({ onConnect }: MetamaskConnectProps) => {
         return;
       }
 
-      await requestAccounts(metamaskProvider);
       setLocalBasicWallet(
         await getBasicSignatureWallet(metamaskProvider, metamaskWalletAddress)
       );
+
       setShowPasswordModal(true);
     }
 

--- a/src/context/MetamaskContext.tsx
+++ b/src/context/MetamaskContext.tsx
@@ -26,6 +26,8 @@ export const MetamaskProvider: React.FC = ({ children }) => {
       dappMetadata: {
         name,
       },
+      // If MetaMask browser extension is detected, directly use it.
+      extensionOnly: true,
     });
 
     let accounts: Partial<unknown>;

--- a/src/utils/metamask.ts
+++ b/src/utils/metamask.ts
@@ -100,16 +100,6 @@ export const getChainId = async (provider: any): Promise<string> =>
   });
 
 /**
- * Gets accounts
- *
- * @param provider Metamask provider
- */
-export const requestAccounts = async (provider: any): Promise<string> =>
-  provider.request({
-    method: 'eth_requestAccounts',
-  });
-
-/**
  * Switches to a network
  *
  * @param provider Metamask provider


### PR DESCRIPTION
Fixed application behavior when connecting a fresh metamask. Previously, an error could occur due to which it would be necessary to connect via Metamask a second time for a successful login.
With changed settings, the application works normally.