### PR TITLE
fix: hide invites for blossom users (#459)

### DIFF
--- a/src/components/NavigationBars/MainSideBar/MainSideBar.tsx
+++ b/src/components/NavigationBars/MainSideBar/MainSideBar.tsx
@@ -28,6 +28,7 @@ import classes from './MainSideBar.module.scss';
 import DriveActionBarMobile from '../DriveActionBar/DriveActionBarMobile';
 import { UpdateDriveProps } from '@interfaces/handlers';
 import { useLocales } from '@context/LocalesContext';
+import { useFdpStorage } from '@context/FdpStorageContext';
 
 interface MainSideBarProps extends UpdateDriveProps {
   driveSideBarToggle: any;
@@ -40,6 +41,7 @@ const MainSideBar: FC<MainSideBarProps> = ({
   refreshPods,
 }) => {
   const { intl } = useLocales();
+  const { loginType } = useFdpStorage();
 
   const items = [
     {
@@ -84,7 +86,10 @@ const MainSideBar: FC<MainSideBarProps> = ({
         },
       },
     },
-    {
+  ];
+
+  if (loginType !== 'blossom') {
+    items.push({
       label: intl.get('INVITE'),
       link: '/invite',
       icons: {
@@ -97,8 +102,8 @@ const MainSideBar: FC<MainSideBarProps> = ({
           inactive: <InviteInactiveDark />,
         },
       },
-    },
-  ];
+    });
+  }
 
   const [renderDriveMenu, setRenderDriveMenu] = useState<boolean>(false);
 


### PR DESCRIPTION
Because invites require access to user's private key, that requires additional changes in Blossom in order to properly implement this page. For that reason this feature won't be available when logged in with Blossom for time being.

Closes #459 