### PR TITLE
feat: pod list

### DIFF
--- a/src/components/Cards/PodCard/PodCard.tsx
+++ b/src/components/Cards/PodCard/PodCard.tsx
@@ -1,0 +1,31 @@
+import ThemeContext from '@context/ThemeContext';
+import { useContext } from 'react';
+import DriveLightIcon from '@media/UI/drive-active-light.svg';
+import DriveDarkIcon from '@media/UI/drive-active-dark.svg';
+import shortenString from '@utils/shortenString';
+
+interface PodCardProps {
+  podName: string;
+  onClick: (podName: string) => void;
+}
+
+export default function PodCard({ podName, onClick }: PodCardProps) {
+  const { theme } = useContext(ThemeContext);
+
+  return (
+    <div
+      className="w-32 mb-2 py-2 py-8 flex-column cursor-pointer dark:hover:shadow-soft-purple hover:shadow-soft-purple"
+      onClick={() => onClick(podName)}
+    >
+      <span className="flex text-color-accents-grey-lavendar dark:text-color-shade-dark-1-night">
+        <div className="mx-auto">
+          {theme === 'light' ? <DriveLightIcon /> : <DriveDarkIcon />}
+        </div>
+      </span>
+
+      <h4 className="text-sm px-1 mt-2 overflow-x-hidden font-medium text-center text-color-shade-light-1-day dark:text-color-shade-light-1-night">
+        {shortenString(podName, 24)}
+      </h4>
+    </div>
+  );
+}

--- a/src/components/Views/PodList/PodList.tsx
+++ b/src/components/Views/PodList/PodList.tsx
@@ -1,0 +1,20 @@
+import { GetPodResponse } from '@api/pod';
+import PodCard from '@components/Cards/PodCard/PodCard';
+
+interface PodListProps {
+  pods: GetPodResponse;
+  onPodSelect: (podName: string) => void;
+}
+
+export default function PodList({ pods, onPodSelect }: PodListProps) {
+  return (
+    <div className="flex justify-center sm:justify-start flex-wrap h-full">
+      {(pods?.pod_name || []).map((pod) => (
+        <PodCard key={pod} podName={pod} onClick={onPodSelect} />
+      ))}
+      {(pods?.shared_pod_name || []).map((pod) => (
+        <PodCard key={pod} podName={pod} onClick={onPodSelect} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/drive/index.tsx
+++ b/src/pages/drive/index.tsx
@@ -36,12 +36,15 @@ import {
 import { RefreshDriveOptions } from '@interfaces/handlers';
 import DirectoryPath from '@components/DirectoryPath/DirectoryPath';
 import { isDataNotFoundError, isJsonParsingError } from '@utils/error';
+import PodList from '@components/Views/PodList/PodList';
 
 const Drive: FC = () => {
   const { trackPageView } = useMatomo();
   const { theme } = useContext(ThemeContext);
   const {
+    pods,
     activePod,
+    setActivePod,
     openPods,
     setPods,
     directoryName,
@@ -270,7 +273,7 @@ const Drive: FC = () => {
         activePod ? (
           <EmptyDirectoryCard />
         ) : (
-          <SelectPodCard />
+          <PodList pods={pods} onPodSelect={setActivePod} />
         )
       ) : null}
       {showPreviewModal ? (


### PR DESCRIPTION
Pod list is shown when no pod is selected, instead of the card element.

Closes #467 