### PR TITLE
fix: removed left padding for mobile

### DIFF
--- a/src/components/Layouts/AuthenticationLayout/AuthenticationLayout.tsx
+++ b/src/components/Layouts/AuthenticationLayout/AuthenticationLayout.tsx
@@ -18,7 +18,7 @@ const AuthenticationLayout: FC<AuthenticationLayoutProps> = ({
   const { theme } = useContext(ThemeContext);
 
   return (
-    <div className="flex pl-2 justify-items-stretch w-screen h-screen dark:bg-color-shade-dark-3-night">
+    <div className="flex md:pl-2 lg:pl-2 justify-items-stretch w-screen h-screen dark:bg-color-shade-dark-3-night">
       <div
         className={`w-0 sm:w-100 bg-auth-${theme} bg-center bg-cover bg-no-repeat`}
       >


### PR DESCRIPTION
Removed left padding for mobile devices only.


Close https://github.com/fairDataSociety/fairdrive-theapp/issues/404

### Old view
<img width="508" alt="Screenshot 2023-09-08 at 14 40 41" src="https://github.com/fairDataSociety/fairdrive-theapp/assets/1595061/7192695d-48fe-485e-8c9d-b21e533c56d7">
<img width="1505" alt="Screenshot 2023-09-08 at 14 40 31" src="https://github.com/fairDataSociety/fairdrive-theapp/assets/1595061/b3a6e2f9-a47c-41ea-ae6f-969aeb5733df">
<img width="651" alt="Screenshot 2023-09-08 at 14 40 20" src="https://github.com/fairDataSociety/fairdrive-theapp/assets/1595061/4ad9aae8-3e74-4aa6-ada1-e7ac3b637f7a">


### New
<img width="537" alt="Screenshot 2023-09-08 at 14 41 34" src="https://github.com/fairDataSociety/fairdrive-theapp/assets/1595061/812c604e-3a6b-4b84-be61-798644174ec3">
<img width="1432" alt="Screenshot 2023-09-08 at 14 41 51" src="https://github.com/fairDataSociety/fairdrive-theapp/assets/1595061/db7749bf-a5eb-401d-85da-1ec8f41ddb08">
<img width="701" alt="Screenshot 2023-09-08 at 14 41 43" src="https://github.com/fairDataSociety/fairdrive-theapp/assets/1595061/680f6412-267a-463c-9770-bc6a146fa3be">