### PR TITLE
fix: spinner for pods (#494)

### DIFF
--- a/src/pages/drive/index.tsx
+++ b/src/pages/drive/index.tsx
@@ -263,7 +263,7 @@ const Drive: FC = () => {
             </span>
           </div>
         ) : null}
-        <Spinner isLoading={loading} />
+        <Spinner isLoading={loading || !pods} />
 
         {!loading &&
           (activePod ? (


### PR DESCRIPTION
Spinner is shown while loading pods.

Closes #494 