### PR TITLE
fix: caching issue (#507)

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -166,7 +166,7 @@ export function getContentItemsCache(
     cache?.[userAddress]?.[podName]?.[path] ?? EMPTY_CACHE_OBJECT_STRING
   );
 
-  return { cache, contentItems };
+  return { cache, contentItems: contentItems || {} };
 }
 
 /**


### PR DESCRIPTION
Fixes potential situation when `JSON.parse` returns undefined. Judging by the #507, that can happen sometimes.