### PR TITLE
feat: multiple file upload (#499)

### DIFF
--- a/src/components/Modals/SideModal/SideModal.tsx
+++ b/src/components/Modals/SideModal/SideModal.tsx
@@ -14,7 +14,7 @@ interface SideModalProps {
   };
   headerTitle: string;
   className?: string;
-  children: ReactChild | ReactChild[];
+  children: React.ReactNode;
 }
 
 const SideModal: FC<SideModalProps> = ({

--- a/src/components/Modals/UploadFileModal/UploadFileModal.tsx
+++ b/src/components/Modals/UploadFileModal/UploadFileModal.tsx
@@ -41,6 +41,9 @@ const UploadFileModal: FC<CreatorModalProps> = ({
   const { fdpClientRef, getAccountAddress } = useFdpStorage();
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: (acceptedFiles: File[]) => {
+      setUploadedItems([]);
+      setFailedUplods([]);
+      setErrorMessage('');
       if (activePod) {
         setFilesToUpload(acceptedFiles);
       }


### PR DESCRIPTION
Multiple file upload.

This can cause some unexpected situations. When multiple files are uploaded, if only one of them fails, the error will be displayed in the modal. Other files might be uploaded successfully but the user won't be aware. Also because of the error current folder content won't be refreshed.