### PR TITLE
fix: metamask migration dialog

### DIFF
--- a/src/components/Dialogs/MetamaskMigrationDialog/MetamaskCreateAccount.tsx
+++ b/src/components/Dialogs/MetamaskMigrationDialog/MetamaskCreateAccount.tsx
@@ -97,7 +97,7 @@ export default function MetamaskCreateAccount({
 
       await fdpClientRef.current.account.register(request);
       setWallet(fdpClientRef.current.account.wallet);
-      setFdpStorageType('native');
+      setFdpStorageType('native', undefined, false);
       setIsLoggedIn(true);
       setLoginType('username');
       setUser(username);

--- a/src/components/Dialogs/MetamaskMigrationDialog/MetamaskMigrationDialog.tsx
+++ b/src/components/Dialogs/MetamaskMigrationDialog/MetamaskMigrationDialog.tsx
@@ -55,7 +55,9 @@ const MetamaskMigrationDialog = ({
     if (clickOutside) {
       return;
     }
-    setMetamaskMigrationNotification('closed');
+    setMetamaskMigrationNotification(
+      step === Step.COMPLETE ? 'completed' : 'closed'
+    );
     onClose();
   };
 

--- a/src/context/FdpStorageContext.tsx
+++ b/src/context/FdpStorageContext.tsx
@@ -70,7 +70,8 @@ interface FdpStorageContext {
   setWallet: (wallet: Wallet) => void;
   setFdpStorageType: (
     type: FDP_STORAGE_TYPE,
-    config?: FdpContracts.EnsEnvironment
+    config?: FdpContracts.EnsEnvironment,
+    create?: boolean
   ) => void;
   setFdpStorageConfig: (config: FdpContracts.EnsEnvironment) => void;
   setUsername: (username: string) => void;
@@ -153,15 +154,19 @@ function FdpStorageProvider(props: FdpStorageContextProps) {
    */
   const setFdpStorageType = (
     type: FDP_STORAGE_TYPE,
-    config?: FdpContracts.EnsEnvironment
+    config?: FdpContracts.EnsEnvironment,
+    create = true
   ) => {
-    if (type === 'native') {
-      fdpClientRef.current = createFdpStorage(config);
-    } else if (type === 'blossom') {
-      fdpClientRef.current = blossom.fdpStorage;
-    } else {
-      throw new Error('Unknown FDP storage type');
+    if (create) {
+      if (type === 'native') {
+        fdpClientRef.current = createFdpStorage(config);
+      } else if (type === 'blossom') {
+        fdpClientRef.current = blossom.fdpStorage;
+      } else {
+        throw new Error('Unknown FDP storage type');
+      }
     }
+
     setIsLoggedIn(false);
     setStorageType(type);
   };

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -305,11 +305,9 @@
   scrollbar-width: none; /* Firefox */
 }
 
-.light {
-  .blurred-text {
-    color: transparent;
-    text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
-  }
+.blurred-text {
+  color: transparent;
+  text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 }
 
 .dark {


### PR DESCRIPTION
Fixes the Metamask migration dialog.
- Being able to access files after migration without logging out
- If the dialog is closed on after migration the indicator from dropdown will disappear
- Blurred mnemonic in light theme  