### PR TITLE
security: npm overrides for 4 remaining HIGH dev-scope alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7188,15 +7188,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -9995,13 +9986,14 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -12474,7 +12466,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -13313,7 +13307,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.1.0",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -16343,7 +16339,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -16790,10 +16788,11 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -20041,7 +20040,9 @@
       "peer": true
     },
     "node_modules/requirejs": {
-      "version": "2.3.6",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
+      "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -20367,6 +20368,16 @@
       "version": "2.20.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -20966,9 +20977,10 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.1.0.tgz",
-      "integrity": "sha512-9vC2SfsJzlej6MAaMPLu8HiBSHGdRAJ9hVFYN1ibZoNkeanmDmLUcIrj6G9DGL7XMJ54AKg/G75akXl1/izTOw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21492,27 +21504,39 @@
       "dev": true
     },
     "node_modules/svgo": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
+        "commander": "^11.1.0",
         "css-select": "^5.1.0",
-        "css-tree": "^2.2.1",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
       },
       "bin": {
-        "svgo": "bin/svgo"
+        "svgo": "bin/svgo.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/swr": {
@@ -28017,7 +28041,7 @@
       "requires": {
         "cosmiconfig": "^8.1.3",
         "deepmerge": "^4.3.1",
-        "svgo": "^3.0.2"
+        "svgo": ">=3.3.3"
       },
       "dependencies": {
         "argparse": {
@@ -28144,7 +28168,7 @@
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.5.6",
-        "lodash": "^4.17.15",
+        "lodash": ">=4.18.0",
         "redent": "^3.0.0"
       },
       "dependencies": {
@@ -28195,12 +28219,6 @@
         "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "^18.0.0"
       }
-    },
-    "@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -29259,7 +29277,7 @@
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
+        "lodash": ">=4.18.0",
         "picomatch": ">=2.3.2"
       }
     },
@@ -30244,13 +30262,13 @@
       }
     },
     "css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "requires": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "css-unit-converter": {
@@ -31969,12 +31987,14 @@
       "version": "3.0.4",
       "dev": true,
       "requires": {
-        "flatted": "^3.1.0",
+        "flatted": ">=3.4.2",
         "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "3.2.7",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "flatten": {
@@ -32522,7 +32542,9 @@
       "peer": true
     },
     "immutable": {
-      "version": "4.1.0",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
       "devOptional": true
     },
     "import-fresh": {
@@ -34674,7 +34696,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.debounce": {
       "version": "4.0.8"
@@ -34985,9 +35009,9 @@
       }
     },
     "mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true
     },
     "memoize-one": {
@@ -35782,7 +35806,7 @@
         "commander": "^2.8.1",
         "debug": "^4.1.0",
         "glob": "^7.1.6",
-        "requirejs": "^2.3.5",
+        "requirejs": ">=2.3.7",
         "requirejs-config-file": "^4.0.0"
       },
       "dependencies": {
@@ -35919,7 +35943,7 @@
       "version": "1.11.0",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": ">=4.18.0"
       }
     },
     "node-fetch": {
@@ -37283,7 +37307,9 @@
       "peer": true
     },
     "requirejs": {
-      "version": "2.3.6",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
+      "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
       "dev": true
     },
     "requirejs-config-file": {
@@ -37463,7 +37489,7 @@
       "devOptional": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
+        "immutable": ">=4.3.8",
         "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
@@ -37479,6 +37505,12 @@
           "dev": true
         }
       }
+    },
+    "sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true
     },
     "scheduler": {
       "version": "0.23.0",
@@ -37926,9 +37958,9 @@
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
     },
     "source-map-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.1.0.tgz",
-      "integrity": "sha512-9vC2SfsJzlej6MAaMPLu8HiBSHGdRAJ9hVFYN1ibZoNkeanmDmLUcIrj6G9DGL7XMJ54AKg/G75akXl1/izTOw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -38302,17 +38334,26 @@
       "dev": true
     },
     "svgo": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "dev": true,
       "requires": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
+        "commander": "^11.1.0",
         "css-select": "^5.1.0",
-        "css-tree": "^2.2.1",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+          "dev": true
+        }
       }
     },
     "swr": {
@@ -38365,7 +38406,7 @@
         "html-tags": "^3.1.0",
         "is-color-stop": "^1.1.0",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.21",
+        "lodash": ">=4.18.0",
         "lodash.topath": "^4.5.2",
         "modern-normalize": "^1.1.0",
         "node-emoji": "^1.11.0",
@@ -39158,7 +39199,7 @@
         "chalk": "^4.1.0",
         "commander": "^6.2.0",
         "gzip-size": "^6.0.0",
-        "lodash": "^4.17.20",
+        "lodash": ">=4.18.0",
         "opener": "^1.5.2",
         "sirv": "^1.0.7",
         "ws": ">=8.17.1"
@@ -39305,7 +39346,7 @@
         "fast-json-stable-stringify": "^2.1.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
-        "lodash": "^4.17.20",
+        "lodash": ">=4.18.0",
         "pretty-bytes": "^5.3.0",
         "rollup": ">=2.80.0",
         "rollup-plugin-terser": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,12 @@
     "serialize-javascript": ">=7.0.5",
     "cross-spawn": ">=6.0.6",
     "rollup": ">=2.80.0",
-    "braces": ">=3.0.3"
+    "braces": ">=3.0.3",
+    "lodash": ">=4.18.0",
+    "flatted": ">=3.4.2",
+    "immutable": ">=4.3.8",
+    "svgo": ">=3.3.3",
+    "requirejs": ">=2.3.7"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^11.1.2",


### PR DESCRIPTION
## Summary

Closes 4 remaining HIGH dev-scope Dependabot alerts via npm `overrides`:

| Alert | Package | Vulnerable | Patched | Scope |
|-------|---------|-----------|---------|-------|
| #71 | flatted | <=3.4.1 | 3.4.2 | dev |
| #66 | immutable | 4.x <4.3.8 | 4.3.8 | dev |
| #65 | svgo | 3.x <3.3.3 | 3.3.3 | dev |
| #7 | requirejs | <=2.3.6 | 2.3.7 | dev |

Also adds `lodash >=4.18.0` override (alert #80 was dismissed as tolerable, belt-and-suspenders).

Package-lock.json regenerated with `npm install --package-lock-only --ignore-scripts`. Resolved versions: flatted@3.4.2, immutable@5.1.6, svgo@4.0.1, requirejs@2.3.8.

**Not included:** Alert #19 (next.js <14.2.15, runtime HIGH) — requires major Next.js upgrade (v12→v14+), tracked separately.

## After merge

fairdrive-theapp status: 0 CRITICAL, 0 HIGH runtime, 0 HIGH dev-scope (4 dev-scope HIGH → resolved; 1 runtime HIGH next.js remains but requires major upgrade track).

## CI note

CI is expected to fail on fdp-play queen boot (pre-existing, tracked in #593). This PR is a security-only change; CI failure is unrelated to these overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)