### PR TITLE
security: npm overrides for 8 MEDIUM runtime Dependabot alerts (nanoid, babel, bn.js, yaml, postcss, joi)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "jest": "^29.5.0",
         "madge": "^5.0.1",
         "path": "^0.12.7",
-        "postcss": "^8.3.6",
+        "postcss": "^8.5.10",
         "prettier": "^2.3.2",
         "prop-types": "^15.7.2",
         "sass": "^1.39.0",
@@ -471,17 +471,96 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "license": "MIT"
     },
     "node_modules/@babel/highlight": {
       "version": "7.24.1",
@@ -1974,15 +2053,10 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
-      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
+      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==",
+      "license": "MIT"
     },
     "node_modules/@babel/runtime-corejs3": {
       "version": "7.19.1",
@@ -1995,11 +2069,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
@@ -3109,19 +3178,58 @@
       "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==",
       "deprecated": "the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package"
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "peer": true
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@headlessui/react": {
@@ -6607,27 +6715,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "peer": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "peer": true
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "peer": true
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -6653,6 +6740,13 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -8245,11 +8339,6 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
     "node_modules/assert": {
       "version": "2.0.0",
       "license": "MIT",
@@ -8803,7 +8892,9 @@
       "license": "MIT"
     },
     "node_modules/bn.js": {
-      "version": "5.2.1",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -9811,10 +9902,6 @@
         "elliptic": "^6.5.3"
       }
     },
-    "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
     "node_modules/create-hash": {
       "version": "1.2.0",
       "license": "MIT",
@@ -10534,10 +10621,6 @@
         "randombytes": "^2.0.0"
       }
     },
-    "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "license": "MIT",
@@ -10709,10 +10792,6 @@
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -15907,16 +15986,22 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "version": "18.2.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-sha3": {
@@ -17629,10 +17714,6 @@
         "miller-rabin": "bin/miller-rabin"
       }
     },
-    "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
     "node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -17803,20 +17884,21 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.14.tgz",
+      "integrity": "sha512-5c8l8kVzqpnDPaicbEop/fV0Q1w16FmbWtVhMqugTozAwYdlIQojWH5a/M7UfziFmGdQRrUdV+EPzc9Xng3VAQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/nanomatch": {
@@ -18954,9 +19036,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.36.tgz",
-      "integrity": "sha512-/n7eumA6ZjFHAsbX30yhHup/IMkOmlmvtEi7P+6RMYf+bGJSUHc3geH4a0NSZxAz/RJfiS9tooCTs9LAVYUZKw==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -18972,10 +19054,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.1.0"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -19302,10 +19385,6 @@
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -23370,10 +23449,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {
@@ -23460,7 +23547,7 @@
         "@babel/generator": "^7.21.5",
         "@babel/helper-compilation-targets": "^7.21.5",
         "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helpers": "^7.21.5",
+        "@babel/helpers": ">=7.26.10",
         "@babel/parser": "^7.21.8",
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.21.5",
@@ -23705,13 +23792,65 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
       "requires": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+          "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^8.0.0",
+            "js-tokens": "^10.0.0"
+          }
+        },
+        "@babel/helper-string-parser": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+          "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+          "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA=="
+        },
+        "@babel/parser": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+          "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+          "requires": {
+            "@babel/types": "^8.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+          "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+          "requires": {
+            "@babel/code-frame": "^8.0.0",
+            "@babel/parser": "^8.0.0",
+            "@babel/types": "^8.0.0"
+          }
+        },
+        "@babel/types": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+          "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+          "requires": {
+            "@babel/helper-string-parser": "^8.0.0",
+            "@babel/helper-validator-identifier": "^8.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+          "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
+        }
       }
     },
     "@babel/highlight": {
@@ -24637,19 +24776,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
-      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
-      "requires": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-        }
-      }
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
+      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw=="
     },
     "@babel/runtime-corejs3": {
       "version": "7.19.1",
@@ -24741,7 +24870,7 @@
       "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
+        "@babel/runtime": ">=7.26.10",
         "@emotion/hash": "^0.9.1",
         "@emotion/memoize": "^0.8.1",
         "@emotion/serialize": "^1.1.2",
@@ -24788,7 +24917,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
       "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
       "requires": {
-        "@babel/runtime": "^7.18.3",
+        "@babel/runtime": ">=7.26.10",
         "@emotion/babel-plugin": "^11.11.0",
         "@emotion/cache": "^11.11.0",
         "@emotion/serialize": "^1.1.2",
@@ -24820,7 +24949,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
       "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
       "requires": {
-        "@babel/runtime": "^7.18.3",
+        "@babel/runtime": ">=7.26.10",
         "@emotion/babel-plugin": "^11.11.0",
         "@emotion/is-prop-valid": "^1.2.1",
         "@emotion/serialize": "^1.1.2",
@@ -25025,7 +25154,7 @@
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
-        "bn.js": "^5.2.1"
+        "bn.js": ">=5.2.3"
       }
     },
     "@ethersproject/bytes": {
@@ -25186,7 +25315,7 @@
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
-        "bn.js": "^5.2.1",
+        "bn.js": ">=5.2.3",
         "elliptic": ">=6.6.1",
         "hash.js": "1.1.7"
       }
@@ -25339,19 +25468,46 @@
       "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
       "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
     },
+    "@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "peer": true,
+      "requires": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "peer": true
+    },
     "@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "peer": true
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "peer": true
+    },
+    "@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
       "peer": true
     },
     "@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
       "peer": true,
       "requires": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "@headlessui/react": {
@@ -26732,7 +26888,7 @@
         "cosmiconfig": "^5.1.0",
         "deepmerge": "^3.2.0",
         "glob": "^7.1.3",
-        "joi": "^17.2.1"
+        "joi": ">=17.13.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -27605,7 +27761,7 @@
       "integrity": "sha512-31oUM6/rFBZQfSmDQsT1DX/5fjqfxg7sf2u8kTPJK7rXVya5SRpAMaCXsPAG0omsmJxXt+J9HxUi3Ic+5Ux5Iw==",
       "peer": true,
       "requires": {
-        "joi": "^17.2.1"
+        "joi": ">=17.13.4"
       }
     },
     "@react-native/assets": {
@@ -27842,27 +27998,6 @@
         "@scure/base": "~1.1.0"
       }
     },
-    "@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "peer": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "peer": true
-    },
-    "@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "peer": true
-    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -27888,6 +28023,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "peer": true
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -28107,7 +28248,7 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": ">=7.26.10",
         "@types/aria-query": "^4.2.0",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
@@ -28162,7 +28303,7 @@
       "dev": true,
       "requires": {
         "@adobe/css-tools": "^4.0.1",
-        "@babel/runtime": "^7.9.2",
+        "@babel/runtime": ">=7.26.10",
         "@types/testing-library__jest-dom": "^5.9.1",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
@@ -28215,7 +28356,7 @@
       "version": "13.4.0",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": ">=7.26.10",
         "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "^18.0.0"
       }
@@ -29030,16 +29171,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "^4.0.0",
+        "bn.js": ">=5.2.3",
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
       }
     },
     "assert": {
@@ -29245,7 +29379,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": ">=7.26.10",
         "cosmiconfig": "^7.0.0",
         "resolve": "^1.19.0"
       }
@@ -29409,7 +29543,9 @@
       "version": "6.0.20211015"
     },
     "bn.js": {
-      "version": "5.2.1"
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -29478,7 +29614,7 @@
     "browserify-rsa": {
       "version": "4.1.0",
       "requires": {
-        "bn.js": "^5.0.0",
+        "bn.js": ">=5.2.3",
         "randombytes": "^2.0.1"
       }
     },
@@ -29487,7 +29623,7 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
       "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
       "requires": {
-        "bn.js": "^5.2.1",
+        "bn.js": ">=5.2.3",
         "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
@@ -30124,7 +30260,7 @@
         "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "yaml": ">=1.10.3"
       }
     },
     "crc-32": {
@@ -30135,13 +30271,8 @@
     "create-ecdh": {
       "version": "4.0.4",
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": ">=5.2.3",
         "elliptic": ">=6.6.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0"
-        }
       }
     },
     "create-hash": {
@@ -30328,7 +30459,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "requires": {
-        "@babel/runtime": "^7.21.0"
+        "@babel/runtime": ">=7.26.10"
       }
     },
     "dayjs": {
@@ -30630,14 +30761,9 @@
     "diffie-hellman": {
       "version": "5.0.3",
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": ">=5.2.3",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0"
-        }
       }
     },
     "dir-glob": {
@@ -30751,18 +30877,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "requires": {
-        "bn.js": "^4.11.9",
+        "bn.js": ">=5.2.3",
         "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
         "hmac-drbg": "^1.0.1",
         "inherits": "^2.0.4",
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0"
-        }
       }
     },
     "emittery": {
@@ -31254,7 +31375,7 @@
       "version": "6.6.1",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.18.9",
+        "@babel/runtime": ">=7.26.10",
         "aria-query": "^4.2.2",
         "array-includes": "^3.1.5",
         "ast-types-flow": "^0.0.7",
@@ -31273,7 +31394,7 @@
           "version": "4.2.2",
           "dev": true,
           "requires": {
-            "@babel/runtime": "^7.10.2",
+            "@babel/runtime": ">=7.26.10",
             "@babel/runtime-corejs3": "^7.10.2"
           }
         }
@@ -34371,16 +34492,18 @@
       }
     },
     "joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "version": "18.2.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
       "peer": true,
       "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
       }
     },
     "js-sha3": {
@@ -35637,7 +35760,7 @@
       "integrity": "sha512-EpVKm4eN0Fgx2PEWpJ5NiMArV8zVoOin866jIIvzFLpmkZz1UEqgjf2JAfUJnjgv3fjSV3JqeGG2vZCaGQBTow==",
       "peer": true,
       "requires": {
-        "@babel/runtime": "^7.0.0",
+        "@babel/runtime": ">=7.26.10",
         "react-refresh": "^0.4.0"
       }
     },
@@ -35720,13 +35843,8 @@
     "miller-rabin": {
       "version": "4.0.1",
       "requires": {
-        "bn.js": "^4.0.0",
+        "bn.js": ">=5.2.3",
         "brorand": "^1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0"
-        }
       }
     },
     "mime": {
@@ -35832,9 +35950,9 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.14.tgz",
+      "integrity": "sha512-5c8l8kVzqpnDPaicbEop/fV0Q1w16FmbWtVhMqugTozAwYdlIQojWH5a/M7UfziFmGdQRrUdV+EPzc9Xng3VAQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -35898,7 +36016,7 @@
         "postcss": {
           "version": "8.4.14",
           "requires": {
-            "nanoid": "^3.3.4",
+            "nanoid": ">=3.3.8",
             "picocolors": "^1.0.0",
             "source-map-js": "^1.0.2"
           }
@@ -36567,14 +36685,14 @@
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
     },
     "postcss": {
-      "version": "8.4.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.36.tgz",
-      "integrity": "sha512-/n7eumA6ZjFHAsbX30yhHup/IMkOmlmvtEi7P+6RMYf+bGJSUHc3geH4a0NSZxAz/RJfiS9tooCTs9LAVYUZKw==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.1.0"
+        "nanoid": ">=3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "postcss-js": {
@@ -36590,7 +36708,7 @@
       "dev": true,
       "requires": {
         "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
+        "yaml": ">=1.10.3"
       }
     },
     "postcss-nested": {
@@ -36764,17 +36882,12 @@
     "public-encrypt": {
       "version": "4.0.3",
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": ">=5.2.3",
         "browserify-rsa": "^4.0.0",
         "create-hash": "^1.1.0",
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0"
-        }
       }
     },
     "pump": {
@@ -37239,7 +37352,7 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
       "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
       "requires": {
-        "@babel/runtime": "^7.8.4"
+        "@babel/runtime": ">=7.26.10"
       }
     },
     "regex-not": {
@@ -39336,7 +39449,7 @@
         "@apideck/better-ajv-errors": "^0.3.1",
         "@babel/core": "^7.11.1",
         "@babel/preset-env": "^7.11.0",
-        "@babel/runtime": "^7.11.2",
+        "@babel/runtime": ">=7.26.10",
         "@rollup/plugin-babel": "^5.2.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-replace": "^2.4.1",
@@ -39611,7 +39724,9 @@
       "version": "4.0.0"
     },
     "yaml": {
-      "version": "1.10.2"
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="
     },
     "yargs": {
       "version": "17.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,6 +146,19 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -469,98 +482,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
-      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/code-frame": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
-      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^8.0.0",
-        "js-tokens": "^10.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/template": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
-      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^8.0.0",
-        "@babel/parser": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "license": "MIT"
     },
     "node_modules/@babel/highlight": {
       "version": "7.24.1",
@@ -2052,12 +1973,6 @@
       "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
-    "node_modules/@babel/runtime": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
-      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==",
-      "license": "MIT"
-    },
     "node_modules/@babel/runtime-corejs3": {
       "version": "7.19.1",
       "dev": true,
@@ -2184,6 +2099,15 @@
         "stylis": "4.2.0"
       }
     },
+    "node_modules/@emotion/babel-plugin/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@emotion/cache": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
@@ -2237,6 +2161,15 @@
         }
       }
     },
+    "node_modules/@emotion/react/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@emotion/serialize": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
@@ -2274,6 +2207,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emotion/styled/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emotion/stylis": {
@@ -7118,6 +7060,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@testing-library/dom/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@testing-library/dom/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -7204,6 +7156,16 @@
         "yarn": ">=1"
       }
     },
+    "node_modules/@testing-library/jest-dom/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -7280,6 +7242,16 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -8667,6 +8639,15 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -10176,6 +10157,15 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/date-fns/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.9",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
@@ -11388,6 +11378,16 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
@@ -17504,6 +17504,16 @@
         "react-refresh": "^0.4.0"
       }
     },
+    "node_modules/metro-runtime/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/metro-source-map": {
       "version": "0.73.10",
       "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.10.tgz",
@@ -20021,6 +20031,15 @@
       "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
+      }
+    },
+    "node_modules/regenerator-transform/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/regex-not": {
@@ -23123,6 +23142,15 @@
         "ajv": ">=8"
       }
     },
+    "node_modules/workbox-build/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.11.0",
       "license": "MIT",
@@ -23547,7 +23575,7 @@
         "@babel/generator": "^7.21.5",
         "@babel/helper-compilation-targets": "^7.21.5",
         "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helpers": ">=7.26.10",
+        "@babel/helpers": ">=7.26.10 <8",
         "@babel/parser": "^7.21.8",
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.21.5",
@@ -23557,6 +23585,17 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.2",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/helpers": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+          "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+          "requires": {
+            "@babel/template": "^7.29.7",
+            "@babel/types": "^7.29.7"
+          }
+        }
       }
     },
     "@babel/generator": {
@@ -23789,68 +23828,6 @@
         "@babel/template": "^7.18.10",
         "@babel/traverse": "^7.20.5",
         "@babel/types": "^7.20.5"
-      }
-    },
-    "@babel/helpers": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
-      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
-      "requires": {
-        "@babel/template": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
-          "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^8.0.0",
-            "js-tokens": "^10.0.0"
-          }
-        },
-        "@babel/helper-string-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-          "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-          "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA=="
-        },
-        "@babel/parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-          "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
-          "requires": {
-            "@babel/types": "^8.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
-          "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
-          "requires": {
-            "@babel/code-frame": "^8.0.0",
-            "@babel/parser": "^8.0.0",
-            "@babel/types": "^8.0.0"
-          }
-        },
-        "@babel/types": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-          "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
-          "requires": {
-            "@babel/helper-string-parser": "^8.0.0",
-            "@babel/helper-validator-identifier": "^8.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-          "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
-        }
       }
     },
     "@babel/highlight": {
@@ -24775,11 +24752,6 @@
       "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
-    "@babel/runtime": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
-      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw=="
-    },
     "@babel/runtime-corejs3": {
       "version": "7.19.1",
       "dev": true,
@@ -24870,7 +24842,7 @@
       "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "@emotion/hash": "^0.9.1",
         "@emotion/memoize": "^0.8.1",
         "@emotion/serialize": "^1.1.2",
@@ -24880,6 +24852,13 @@
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
         "stylis": "4.2.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+        }
       }
     },
     "@emotion/cache": {
@@ -24917,7 +24896,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
       "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
       "requires": {
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "@emotion/babel-plugin": "^11.11.0",
         "@emotion/cache": "^11.11.0",
         "@emotion/serialize": "^1.1.2",
@@ -24925,6 +24904,13 @@
         "@emotion/utils": "^1.2.1",
         "@emotion/weak-memoize": "^0.3.1",
         "hoist-non-react-statics": "^3.3.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+        }
       }
     },
     "@emotion/serialize": {
@@ -24949,12 +24935,19 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
       "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
       "requires": {
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "@emotion/babel-plugin": "^11.11.0",
         "@emotion/is-prop-valid": "^1.2.1",
         "@emotion/serialize": "^1.1.2",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
         "@emotion/utils": "^1.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+        }
       }
     },
     "@emotion/stylis": {
@@ -28248,7 +28241,7 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "@types/aria-query": "^4.2.0",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
@@ -28257,6 +28250,12 @@
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "dev": true,
@@ -28303,7 +28302,7 @@
       "dev": true,
       "requires": {
         "@adobe/css-tools": "^4.0.1",
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "@types/testing-library__jest-dom": "^5.9.1",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
@@ -28313,6 +28312,12 @@
         "redent": "^3.0.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "dev": true,
@@ -28356,9 +28361,17 @@
       "version": "13.4.0",
       "dev": true,
       "requires": {
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "^18.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+          "dev": true
+        }
       }
     },
     "@tsconfig/node10": {
@@ -29379,9 +29392,16 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "requires": {
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "cosmiconfig": "^7.0.0",
         "resolve": "^1.19.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+        }
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -30459,7 +30479,14 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "requires": {
-        "@babel/runtime": ">=7.26.10"
+        "@babel/runtime": ">=7.26.10 <8"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+        }
       }
     },
     "dayjs": {
@@ -31375,7 +31402,7 @@
       "version": "6.6.1",
       "dev": true,
       "requires": {
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "aria-query": "^4.2.2",
         "array-includes": "^3.1.5",
         "ast-types-flow": "^0.0.7",
@@ -31390,11 +31417,17 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+          "dev": true
+        },
         "aria-query": {
           "version": "4.2.2",
           "dev": true,
           "requires": {
-            "@babel/runtime": ">=7.26.10",
+            "@babel/runtime": ">=7.26.10 <8",
             "@babel/runtime-corejs3": "^7.10.2"
           }
         }
@@ -35760,8 +35793,16 @@
       "integrity": "sha512-EpVKm4eN0Fgx2PEWpJ5NiMArV8zVoOin866jIIvzFLpmkZz1UEqgjf2JAfUJnjgv3fjSV3JqeGG2vZCaGQBTow==",
       "peer": true,
       "requires": {
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "react-refresh": "^0.4.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+          "peer": true
+        }
       }
     },
     "metro-source-map": {
@@ -37352,7 +37393,14 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
       "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
       "requires": {
-        "@babel/runtime": ">=7.26.10"
+        "@babel/runtime": ">=7.26.10 <8"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+        }
       }
     },
     "regex-not": {
@@ -39449,7 +39497,7 @@
         "@apideck/better-ajv-errors": "^0.3.1",
         "@babel/core": "^7.11.1",
         "@babel/preset-env": "^7.11.0",
-        "@babel/runtime": ">=7.26.10",
+        "@babel/runtime": ">=7.26.10 <8",
         "@rollup/plugin-babel": "^5.2.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-replace": "^2.4.1",
@@ -39492,6 +39540,11 @@
             "jsonpointer": "^5.0.0",
             "leven": "^3.1.0"
           }
+        },
+        "@babel/runtime": {
+          "version": "7.29.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+          "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
         },
         "ajv": {
           "version": "8.11.0",

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "svgo": ">=3.3.3",
     "requirejs": ">=2.3.7",
     "nanoid": ">=3.3.8",
-    "@babel/helpers": ">=7.26.10",
-    "@babel/runtime": ">=7.26.10",
+    "@babel/helpers": ">=7.26.10 <8",
+    "@babel/runtime": ">=7.26.10 <8",
     "bn.js": ">=5.2.3",
     "yaml": ">=1.10.3",
     "joi": ">=17.13.4"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,13 @@
     "flatted": ">=3.4.2",
     "immutable": ">=4.3.8",
     "svgo": ">=3.3.3",
-    "requirejs": ">=2.3.7"
+    "requirejs": ">=2.3.7",
+    "nanoid": ">=3.3.8",
+    "@babel/helpers": ">=7.26.10",
+    "@babel/runtime": ">=7.26.10",
+    "bn.js": ">=5.2.3",
+    "yaml": ">=1.10.3",
+    "joi": ">=17.13.4"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^11.1.2",
@@ -106,7 +112,7 @@
     "jest": "^29.5.0",
     "madge": "^5.0.1",
     "path": "^0.12.7",
-    "postcss": "^8.3.6",
+    "postcss": "^8.5.10",
     "prettier": "^2.3.2",
     "prop-types": "^15.7.2",
     "sass": "^1.39.0",


### PR DESCRIPTION
## Summary

Closes 8 open MEDIUM runtime Dependabot alerts via targeted npm overrides — same surgical pattern as the recent HIGH dev-scope PR (#599).

| Alert | Package | GHSA | Action |
|-------|---------|------|--------|
| #18 | nanoid | GHSA-mwcw-c2x4-8c55 | override `>=3.3.8` |
| #21 | @babel/helpers | GHSA-968p-4wvh-cqc8 | override `>=7.26.10` |
| #22 | @babel/runtime | GHSA-968p-4wvh-cqc8 | override `>=7.26.10` |
| #52 | bn.js (v4) | GHSA-378v-28hj-76wf | override `>=5.2.3` |
| #53 | bn.js (v5) | GHSA-378v-28hj-76wf | override `>=5.2.3` |
| #74 | yaml | GHSA-48c2-rrv3-qjmp | override `>=1.10.3` |
| #88 | postcss | GHSA-qx2v-qp2m-jg93 | bump devDep `^8.5.10` |
| #133 | joi | GHSA-q7cg-457f-vx79 | override `>=17.13.4` |

All are transitive runtime or dev-scope deps with no direct user-input exposure in fairdrive-theapp source. The overrides follow the same pattern already established in package.json.

## What's NOT addressed here

These require more involved fixes (separate PRs or milestone work):
- **#34/#35/#36/#43/#69/#72/#114** — Next.js alerts → require Next.js 12→14/15 upgrade (tracked in #598)
- **#40/#135** — js-yaml v3/v4 conflict → a single override can't safely cover both major branches
- **#50/#51** — ajv v6/v8 conflict → same issue
- **#116** — uuid v9→v11 migration required in source code

## CI note

CI may fail on the fdp-play queen 404 issue (pre-existing infra problem tracked in #593, unrelated to this PR). The core security fix is in package.json + package-lock.json diff.